### PR TITLE
Removed hidden dependencies

### DIFF
--- a/lib/fastlane/plugin/bugsnag_sourcemaps_upload/helper/bugsnag_sourcemaps_upload_helper.rb
+++ b/lib/fastlane/plugin/bugsnag_sourcemaps_upload/helper/bugsnag_sourcemaps_upload_helper.rb
@@ -10,7 +10,7 @@ module Fastlane
       #
       def self.create_bundle(platform, entry_file, path, bundle_path)
         UI.message("Creating React Native bundle")
-        Action.sh("react-native bundle \
+        Action.sh("npx react-native bundle \
           --dev false \
           --platform #{platform} \
           --bundle-output #{bundle_path} \

--- a/lib/fastlane/plugin/bugsnag_sourcemaps_upload/helper/bugsnag_sourcemaps_upload_helper.rb
+++ b/lib/fastlane/plugin/bugsnag_sourcemaps_upload/helper/bugsnag_sourcemaps_upload_helper.rb
@@ -19,7 +19,7 @@ module Fastlane
       end
 
       def self.upload_bundle(api_key, platform, app_version, code_bundle_id, path, bundle_path, minified_url, strip, overwrite, wildcard_prefix, upload_sources, upload_modules, endpoint)
-        command = "bugsnag-sourcemaps upload --api-key #{api_key} --source-map #{path} --minified-file #{bundle_path} "
+        command = "npx bugsnag-sourcemaps upload --api-key #{api_key} --source-map #{path} --minified-file #{bundle_path} "
         if upload_sources
           command += "--upload-sources "
         end

--- a/lib/fastlane/plugin/bugsnag_sourcemaps_upload/version.rb
+++ b/lib/fastlane/plugin/bugsnag_sourcemaps_upload/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module BugsnagSourcemapsUpload
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Docs didn't say you needed to have react-native-cli and bugsnag-bugsnag-sourcemaps installed. Switched both to use NPX per the docs of both packages.